### PR TITLE
feat(perf): performance enhancements from span and generated regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ All non-`try` functions will throw a `FormatException` on an invalid format.
 
 As of `2023-04-04`, some available sidecodes that this library considers valid, haven't been distributed yet.
 
+For maximum performance and minimum memory requirements, use the `ReadOnlySpan<char>` overloads.
+
 ## Usage
 ```csharp
 // create instance

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ All non-`try` functions will throw a `FormatException` on an invalid format.
 
 As of `2023-04-04`, some available sidecodes that this library considers valid, haven't been distributed yet.
 
-For maximum performance and minimum memory requirements, use the `ReadOnlySpan<char>` overloads.
-
 ## Usage
 ```csharp
 // create instance

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -34,34 +34,4 @@ public class PerformanceTests
     {
         return Kenteken.TryParse("55-GJ-GJ", out _);
     }
-    
-    [Benchmark]
-    public int? ReadOnlySpan_GetSidecode()
-    {
-        return Kenteken.GetSidecode("55-GJ-GJ".AsSpan());
-    }
-    
-    [Benchmark]
-    public bool ReadOnlySpan_Validate()
-    {
-        return Kenteken.Validate("55-GJ-GJ".AsSpan());
-    }
-
-    [Benchmark]
-    public string ReadOnlySpan_Format()
-    {
-        return new Kenteken("55GJGJ".AsSpan()).Formatted;
-    }
-    
-    [Benchmark]
-    public Kenteken ReadOnlySpan_New()
-    {
-        return new Kenteken("55-GJ-GJ".AsSpan());
-    }
-    
-    [Benchmark]
-    public bool ReadOnlySpan_TryParse()
-    {
-        return Kenteken.TryParse("55-GJ-GJ".AsSpan(), out _);
-    }
 }

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -34,4 +34,34 @@ public class PerformanceTests
     {
         return Kenteken.TryParse("55-GJ-GJ", out _);
     }
+    
+    [Benchmark]
+    public int? ReadOnlySpan_GetSidecode()
+    {
+        return Kenteken.GetSidecode("55-GJ-GJ".AsSpan());
+    }
+    
+    [Benchmark]
+    public bool ReadOnlySpan_Validate()
+    {
+        return Kenteken.Validate("55-GJ-GJ".AsSpan());
+    }
+
+    [Benchmark]
+    public string ReadOnlySpan_Format()
+    {
+        return new Kenteken("55GJGJ".AsSpan()).Formatted;
+    }
+    
+    [Benchmark]
+    public Kenteken ReadOnlySpan_New()
+    {
+        return new Kenteken("55-GJ-GJ".AsSpan());
+    }
+    
+    [Benchmark]
+    public bool ReadOnlySpan_TryParse()
+    {
+        return Kenteken.TryParse("55-GJ-GJ".AsSpan(), out _);
+    }
 }

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -16,7 +16,7 @@ public class PerformanceTests
         "9-XXX-99",
         "XX-999-X",
         "X-999-XX",
-        "XXX-99-x",
+        "XXX-99-X",
         "X-99-XXX",
         "9-XX-999",
         "999-XX-9"

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -21,7 +21,7 @@ public class PerformanceTests
         "9-XX-999",
         "999-XX-9"
     )]
-    public string Input { get; set; }
+    public string Input { get; set; } = default!;
     
     [Benchmark]
     public int? GetSidecode()

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -5,22 +5,7 @@ namespace Tvans.Kenteken.PerformanceTests;
 [MemoryDiagnoser]
 public class PerformanceTests
 {
-    [Params(
-        "99-XX-XX", 
-        "99-99-XX",
-        "99-XX-99",
-        "XX-99-XX",
-        "XX-XX-99",
-        "99-XX-XX",
-        "99-XXX-9",
-        "9-XXX-99",
-        "XX-999-X",
-        "X-999-XX",
-        "XXX-99-X",
-        "X-99-XXX",
-        "9-XX-999",
-        "999-XX-9"
-    )]
+    [Params("99-XX-XX", "99-99-XX", "99-XX-99")]
     public string Input { get; set; } = default!;
     
     [Benchmark]

--- a/perf/PerformanceTests.cs
+++ b/perf/PerformanceTests.cs
@@ -5,33 +5,33 @@ namespace Tvans.Kenteken.PerformanceTests;
 [MemoryDiagnoser]
 public class PerformanceTests
 {
+    [Params(
+        "99-XX-XX", 
+        "99-99-XX",
+        "99-XX-99",
+        "XX-99-XX",
+        "XX-XX-99",
+        "99-XX-XX",
+        "99-XXX-9",
+        "9-XXX-99",
+        "XX-999-X",
+        "X-999-XX",
+        "XXX-99-x",
+        "X-99-XXX",
+        "9-XX-999",
+        "999-XX-9"
+    )]
+    public string Input { get; set; }
+    
     [Benchmark]
     public int? GetSidecode()
     {
-        return Kenteken.GetSidecode("55-GJ-GJ");
-    }
-    
-    [Benchmark]
-    public bool Validate()
-    {
-        return Kenteken.Validate("55-GJ-GJ");
-    }
-
-    [Benchmark]
-    public string Format()
-    {
-        return new Kenteken("55GJGJ").Formatted;
+        return Kenteken.GetSidecode(Input);
     }
     
     [Benchmark]
     public Kenteken New()
     {
-        return new Kenteken("55-GJ-GJ");
-    }
-    
-    [Benchmark]
-    public bool TryParse()
-    {
-        return Kenteken.TryParse("55-GJ-GJ", out _);
+        return new Kenteken(Input);
     }
 }

--- a/src/Formats.cs
+++ b/src/Formats.cs
@@ -4,44 +4,88 @@ namespace Tvans.Kenteken;
 
 internal static class Formats
 {
-    public static int? GetSidecode(string input) => Sidecodes.FirstOrDefault(r => Regex.IsMatch(input, r.Regex, RegexOptions.IgnoreCase)) switch
+    public static int? GetSidecode(string input) =>
+        Sidecodes.FirstOrDefault(r => Regex.IsMatch(input, r.Regex, RegexOptions.IgnoreCase)) switch
+        {
+            (var sidecode and >= 13, _) => DisallowedFromSidecode13Onwards.Any(input.Contains) ? null : sidecode,
+            (var sidecode and >= 8, _) => DisallowedFromSidecode8Onwards.Any(input.Contains) ? null : sidecode,
+            (var sidecode and >= 1, _) => Disallowed.Any(input.Contains) ? null : sidecode,
+            (_, _) => null
+        };
+
+    public static int? GetSidecode(ReadOnlySpan<char> input)
     {
-        (var sidecode and >= 13, _) => DisallowedFromSidecode13Onwards.Any(input.Contains) ? null : sidecode,
-        (var sidecode and >= 8, _) => DisallowedFromSidecode8Onwards.Any(input.Contains) ? null : sidecode,
-        (var sidecode and >= 1, _) => Disallowed.Any(input.Contains) ? null : sidecode,
-        (_, _) => null
-    };
-    
+        for (var i = 0; i < Sidecodes.Length; i++)
+        {
+            if (Regex.IsMatch(input, Sidecodes[i].Regex, RegexOptions.IgnoreCase))
+            {
+                if (Sidecodes[i].Sidecode >= 13)
+                {
+                    if (ContainsDisallowedSequence(input, DisallowedFromSidecode13Onwards)) return null;
+                    return Sidecodes[i].Sidecode;
+                }
+
+                if (Sidecodes[i].Sidecode >= 8)
+                {
+                    if (ContainsDisallowedSequence(input, DisallowedFromSidecode8Onwards)) return null;
+                    return Sidecodes[i].Sidecode;
+                }
+
+                if (ContainsDisallowedSequence(input, Disallowed)) return null;
+                return Sidecodes[i].Sidecode;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ContainsDisallowedSequence(ReadOnlySpan<char> input, string[] disallowed)
+    {
+        for (var i = 0; i < disallowed.Length; i++)
+        {
+            var span = disallowed[i].AsSpan();
+            if (input.Contains(span, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static readonly (int Sidecode, string Regex)[] Sidecodes =
     {
-        new(1,  $"([{AllowedInSidecode1}]{{2}})-?([0-9]{{2}})-?([0-9]{{2}})"),                                    // AB-99-99
-        new(2,  $"([0-9]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode2}]{{2}})"),                                    // 89-67-NR
-        new(3,  $"([0-9]{{2}})-?([{AllowedInSidecode3}]{{2}})-?([0-9]{{2}})"),                                    // 00-FB-63
-        new(4,  $"([{AllowedInSidecode4}]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode4}]{{2}})"),                   // MG-51-TH
-        new(5,  $"([{AllowedInSidecode5}]{{2}})-?([{AllowedInSidecode5}]{{2}})-?([0-9]{{2}})"),                   // RR-HH-02
-        new(6,  $"([0-9]{{2}})-?([{AllowedInSidecode6}]{{2}})-?([{AllowedInSidecode6}]{{2}})"),                   // 88-XD-VV
-        new(7,  $"([0-9]{{2}})-?([{AllowedInSidecode7}]{{3}})-?([0-9]{{1}})"),                                    // 46-GZB-8
-        new(8,  $"([0-9]{{1}})-?([{AllowedInSidecode8}]{{3}})-?([0-9]{{2}})"),                                    // 6-VGF-86
-        new(9,  $"([{AllowedInSidecode9}]{{2}})-?([0-9]{{3}})?-([{AllowedInSidecode9}]{{1}})"),                   // FX-149-H
-        new(10, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{3}})?-([{AllowedInSidecode10Onwards}]{{2}})"),   // V-221-FX
-        new(11, $"([{AllowedInSidecode10Onwards}]{{3}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{1}})"),   // DHN-19-D
-        new(12, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{3}})"),   // T-00-XXX
-        new(13, $"([0-9]{{1}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{3}})"),                            // 9-XX-999
-        new(14, $"([0-9]{{3}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{1}})"),                            // 999-XX-9
+        new(1, $"([{AllowedInSidecode1}]{{2}})-?([0-9]{{2}})-?([0-9]{{2}})"), // AB-99-99
+        new(2, $"([0-9]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode2}]{{2}})"), // 89-67-NR
+        new(3, $"([0-9]{{2}})-?([{AllowedInSidecode3}]{{2}})-?([0-9]{{2}})"), // 00-FB-63
+        new(4, $"([{AllowedInSidecode4}]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode4}]{{2}})"), // MG-51-TH
+        new(5, $"([{AllowedInSidecode5}]{{2}})-?([{AllowedInSidecode5}]{{2}})-?([0-9]{{2}})"), // RR-HH-02
+        new(6, $"([0-9]{{2}})-?([{AllowedInSidecode6}]{{2}})-?([{AllowedInSidecode6}]{{2}})"), // 88-XD-VV
+        new(7, $"([0-9]{{2}})-?([{AllowedInSidecode7}]{{3}})-?([0-9]{{1}})"), // 46-GZB-8
+        new(8, $"([0-9]{{1}})-?([{AllowedInSidecode8}]{{3}})-?([0-9]{{2}})"), // 6-VGF-86
+        new(9, $"([{AllowedInSidecode9}]{{2}})-?([0-9]{{3}})?-([{AllowedInSidecode9}]{{1}})"), // FX-149-H
+        new(10, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{3}})?-([{AllowedInSidecode10Onwards}]{{2}})"), // V-221-FX
+        new(11, $"([{AllowedInSidecode10Onwards}]{{3}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{1}})"), // DHN-19-D
+        new(12, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{3}})"), // T-00-XXX
+        new(13, $"([0-9]{{1}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{3}})"), // 9-XX-999
+        new(14, $"([0-9]{{3}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{1}})"), // 999-XX-9
     };
-    
-    private const string AllowedInSidecode1 =           "ABDEFGHJKLMNOPRSTUVXZ";
-    private const string AllowedInSidecode2 =           "ABDEFGHIJMNOPRSTUVXZ";
-    private const string AllowedInSidecode3 =           "ABDEFGHIJMNOPRSTUVXYZ";
-    private const string AllowedInSidecode4 =           "BDFGHJKLMNOPRSTVWXYZ";
-    private const string AllowedInSidecode5 =           "BDFGHJLMNOPRSTVWXZ";
-    private const string AllowedInSidecode6 =           "BDFGHJLMNOPRSTVWXZ";
-    private const string AllowedInSidecode7 =           "BDFGHJKLMNOPRSTVWXZ";
-    private const string AllowedInSidecode8 =           "BDFGHJKMNOPRSTVWXZ";
-    private const string AllowedInSidecode9 =           "BDFGHJKMNOPRSTVWXZ";
-    private const string AllowedInSidecode10Onwards =   "BDFGHJKLMNOPRSTVWXZ";
 
-    private static readonly string[] Disallowed = { "SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS" };
-    private static readonly string[] DisallowedFromSidecode8Onwards = Disallowed.Concat(new [] { "KVT, VVD" }).ToArray();
-    private static readonly string[] DisallowedFromSidecode13Onwards = DisallowedFromSidecode8Onwards.Concat(new [] { "SP" }).ToArray();
+    private const string AllowedInSidecode1 = "ABDEFGHJKLMNOPRSTUVXZ";
+    private const string AllowedInSidecode2 = "ABDEFGHIJMNOPRSTUVXZ";
+    private const string AllowedInSidecode3 = "ABDEFGHIJMNOPRSTUVXYZ";
+    private const string AllowedInSidecode4 = "BDFGHJKLMNOPRSTVWXYZ";
+    private const string AllowedInSidecode5 = "BDFGHJLMNOPRSTVWXZ";
+    private const string AllowedInSidecode6 = "BDFGHJLMNOPRSTVWXZ";
+    private const string AllowedInSidecode7 = "BDFGHJKLMNOPRSTVWXZ";
+    private const string AllowedInSidecode8 = "BDFGHJKMNOPRSTVWXZ";
+    private const string AllowedInSidecode9 = "BDFGHJKMNOPRSTVWXZ";
+    private const string AllowedInSidecode10Onwards = "BDFGHJKLMNOPRSTVWXZ";
+
+    private static readonly string[] Disallowed =
+        {"SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS"};
+
+    private static readonly string[] DisallowedFromSidecode8Onwards = Disallowed.Concat(new[] {"KVT, VVD"}).ToArray();
+
+    private static readonly string[] DisallowedFromSidecode13Onwards =
+        DisallowedFromSidecode8Onwards.Concat(new[] {"SP"}).ToArray();
 }

--- a/src/Formats.cs
+++ b/src/Formats.cs
@@ -7,6 +7,8 @@ internal static partial class Formats
     public static int? GetSidecode(ReadOnlySpan<char> input)
     {
         var sidecode = GetsidecodeFromRegex(input);
+        if (sidecode is null) return null;
+        
         if (sidecode >= 13)
         {
             if (ContainsDisallowedSequence(input, DisallowedFromSidecode13Onwards)) return null;

--- a/src/Formats.cs
+++ b/src/Formats.cs
@@ -2,32 +2,43 @@
 
 namespace Tvans.Kenteken;
 
-internal static class Formats
+internal static partial class Formats
 {
     public static int? GetSidecode(ReadOnlySpan<char> input)
     {
-        for (var i = 0; i < Sidecodes.Length; i++)
+        var sidecode = GetsidecodeFromRegex(input);
+        if (sidecode >= 13)
         {
-            if (Regex.IsMatch(input, Sidecodes[i], RegexOptions.IgnoreCase))
-            {
-                var sidecode = i + 1;
-                if (sidecode >= 13)
-                {
-                    if (ContainsDisallowedSequence(input, DisallowedFromSidecode13Onwards)) return null;
-                    return sidecode;
-                }
-
-                if (sidecode >= 8)
-                {
-                    if (ContainsDisallowedSequence(input, DisallowedFromSidecode8Onwards)) return null;
-                    return sidecode;
-                }
-
-                if (ContainsDisallowedSequence(input, Disallowed)) return null;
-                return sidecode;
-            }
+            if (ContainsDisallowedSequence(input, DisallowedFromSidecode13Onwards)) return null;
+            return sidecode;
         }
 
+        if (sidecode >= 8)
+        {
+            if (ContainsDisallowedSequence(input, DisallowedFromSidecode8Onwards)) return null;
+            return sidecode;
+        }
+
+        if (ContainsDisallowedSequence(input, Disallowed)) return null;
+        return sidecode;
+    }
+
+    private static int? GetsidecodeFromRegex(ReadOnlySpan<char> input)
+    {
+        if (SideCode1Regex().IsMatch(input)) return 1;
+        if (SideCode2Regex().IsMatch(input)) return 2;
+        if (SideCode3Regex().IsMatch(input)) return 3;
+        if (SideCode4Regex().IsMatch(input)) return 4;
+        if (SideCode5Regex().IsMatch(input)) return 5;
+        if (SideCode6Regex().IsMatch(input)) return 6;
+        if (SideCode7Regex().IsMatch(input)) return 7;
+        if (SideCode8Regex().IsMatch(input)) return 8;
+        if (SideCode9Regex().IsMatch(input)) return 9;
+        if (SideCode10Regex().IsMatch(input)) return 10;
+        if (SideCode11Regex().IsMatch(input)) return 11;
+        if (SideCode12Regex().IsMatch(input)) return 12;
+        if (SideCode13Regex().IsMatch(input)) return 13;
+        if (SideCode14Regex().IsMatch(input)) return 14;
         return null;
     }
 
@@ -82,4 +93,60 @@ internal static class Formats
 
     private static readonly string[] DisallowedFromSidecode13Onwards =
         {"SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS", "KVT", "VVD", "SP"};
+
+    [GeneratedRegex($"([{AllowedInSidecode1}]{{2}})-?([0-9]{{2}})-?([0-9]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode1Regex();
+
+    [GeneratedRegex($"([0-9]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode2}]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode2Regex();
+
+    [GeneratedRegex($"([0-9]{{2}})-?([{AllowedInSidecode3}]{{2}})-?([0-9]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode3Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode4}]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode4}]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode4Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode5}]{{2}})-?([{AllowedInSidecode5}]{{2}})-?([0-9]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode5Regex();
+
+    [GeneratedRegex($"([0-9]{{2}})-?([{AllowedInSidecode6}]{{2}})-?([{AllowedInSidecode6}]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode6Regex();
+
+    [GeneratedRegex($"([0-9]{{2}})-?([{AllowedInSidecode7}]{{3}})-?([0-9]{{1}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode7Regex();
+
+    [GeneratedRegex($"([0-9]{{1}})-?([{AllowedInSidecode8}]{{3}})-?([0-9]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode8Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode9}]{{2}})-?([0-9]{{3}})?-([{AllowedInSidecode9}]{{1}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode9Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{3}})?-([{AllowedInSidecode10Onwards}]{{2}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode10Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode10Onwards}]{{3}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{1}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode11Regex();
+
+    [GeneratedRegex($"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{3}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode12Regex();
+
+    [GeneratedRegex($"([0-9]{{1}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{3}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode13Regex();
+
+    [GeneratedRegex($"([0-9]{{3}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{1}})",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex SideCode14Regex();
 }

--- a/src/Formats.cs
+++ b/src/Formats.cs
@@ -4,35 +4,27 @@ namespace Tvans.Kenteken;
 
 internal static class Formats
 {
-    public static int? GetSidecode(string input) =>
-        Sidecodes.FirstOrDefault(r => Regex.IsMatch(input, r.Regex, RegexOptions.IgnoreCase)) switch
-        {
-            (var sidecode and >= 13, _) => DisallowedFromSidecode13Onwards.Any(input.Contains) ? null : sidecode,
-            (var sidecode and >= 8, _) => DisallowedFromSidecode8Onwards.Any(input.Contains) ? null : sidecode,
-            (var sidecode and >= 1, _) => Disallowed.Any(input.Contains) ? null : sidecode,
-            (_, _) => null
-        };
-
     public static int? GetSidecode(ReadOnlySpan<char> input)
     {
         for (var i = 0; i < Sidecodes.Length; i++)
         {
-            if (Regex.IsMatch(input, Sidecodes[i].Regex, RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(input, Sidecodes[i], RegexOptions.IgnoreCase))
             {
-                if (Sidecodes[i].Sidecode >= 13)
+                var sidecode = i + 1;
+                if (sidecode >= 13)
                 {
                     if (ContainsDisallowedSequence(input, DisallowedFromSidecode13Onwards)) return null;
-                    return Sidecodes[i].Sidecode;
+                    return sidecode;
                 }
 
-                if (Sidecodes[i].Sidecode >= 8)
+                if (sidecode >= 8)
                 {
                     if (ContainsDisallowedSequence(input, DisallowedFromSidecode8Onwards)) return null;
-                    return Sidecodes[i].Sidecode;
+                    return sidecode;
                 }
 
                 if (ContainsDisallowedSequence(input, Disallowed)) return null;
-                return Sidecodes[i].Sidecode;
+                return sidecode;
             }
         }
 
@@ -49,25 +41,26 @@ internal static class Formats
                 return true;
             }
         }
+
         return false;
     }
 
-    public static readonly (int Sidecode, string Regex)[] Sidecodes =
+    public static readonly string[] Sidecodes =
     {
-        new(1, $"([{AllowedInSidecode1}]{{2}})-?([0-9]{{2}})-?([0-9]{{2}})"), // AB-99-99
-        new(2, $"([0-9]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode2}]{{2}})"), // 89-67-NR
-        new(3, $"([0-9]{{2}})-?([{AllowedInSidecode3}]{{2}})-?([0-9]{{2}})"), // 00-FB-63
-        new(4, $"([{AllowedInSidecode4}]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode4}]{{2}})"), // MG-51-TH
-        new(5, $"([{AllowedInSidecode5}]{{2}})-?([{AllowedInSidecode5}]{{2}})-?([0-9]{{2}})"), // RR-HH-02
-        new(6, $"([0-9]{{2}})-?([{AllowedInSidecode6}]{{2}})-?([{AllowedInSidecode6}]{{2}})"), // 88-XD-VV
-        new(7, $"([0-9]{{2}})-?([{AllowedInSidecode7}]{{3}})-?([0-9]{{1}})"), // 46-GZB-8
-        new(8, $"([0-9]{{1}})-?([{AllowedInSidecode8}]{{3}})-?([0-9]{{2}})"), // 6-VGF-86
-        new(9, $"([{AllowedInSidecode9}]{{2}})-?([0-9]{{3}})?-([{AllowedInSidecode9}]{{1}})"), // FX-149-H
-        new(10, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{3}})?-([{AllowedInSidecode10Onwards}]{{2}})"), // V-221-FX
-        new(11, $"([{AllowedInSidecode10Onwards}]{{3}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{1}})"), // DHN-19-D
-        new(12, $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{3}})"), // T-00-XXX
-        new(13, $"([0-9]{{1}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{3}})"), // 9-XX-999
-        new(14, $"([0-9]{{3}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{1}})"), // 999-XX-9
+        $"([{AllowedInSidecode1}]{{2}})-?([0-9]{{2}})-?([0-9]{{2}})", // AB-99-99
+        $"([0-9]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode2}]{{2}})", // 89-67-NR
+        $"([0-9]{{2}})-?([{AllowedInSidecode3}]{{2}})-?([0-9]{{2}})", // 00-FB-63
+        $"([{AllowedInSidecode4}]{{2}})-?([0-9]{{2}})-?([{AllowedInSidecode4}]{{2}})", // MG-51-TH
+        $"([{AllowedInSidecode5}]{{2}})-?([{AllowedInSidecode5}]{{2}})-?([0-9]{{2}})", // RR-HH-02
+        $"([0-9]{{2}})-?([{AllowedInSidecode6}]{{2}})-?([{AllowedInSidecode6}]{{2}})", // 88-XD-VV
+        $"([0-9]{{2}})-?([{AllowedInSidecode7}]{{3}})-?([0-9]{{1}})", // 46-GZB-8
+        $"([0-9]{{1}})-?([{AllowedInSidecode8}]{{3}})-?([0-9]{{2}})", // 6-VGF-86
+        $"([{AllowedInSidecode9}]{{2}})-?([0-9]{{3}})?-([{AllowedInSidecode9}]{{1}})", // FX-149-H
+        $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{3}})?-([{AllowedInSidecode10Onwards}]{{2}})", // V-221-FX
+        $"([{AllowedInSidecode10Onwards}]{{3}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{1}})", // DHN-19-D
+        $"([{AllowedInSidecode10Onwards}]{{1}})-?([0-9]{{2}})?-([{AllowedInSidecode10Onwards}]{{3}})", // T-00-XXX
+        $"([0-9]{{1}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{3}})", // 9-XX-999
+        $"([0-9]{{3}})-?(([{AllowedInSidecode10Onwards}]{{2}})?-[0-9]{{1}})", // 999-XX-9
     };
 
     private const string AllowedInSidecode1 = "ABDEFGHJKLMNOPRSTUVXZ";
@@ -84,8 +77,9 @@ internal static class Formats
     private static readonly string[] Disallowed =
         {"SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS"};
 
-    private static readonly string[] DisallowedFromSidecode8Onwards = Disallowed.Concat(new[] {"KVT, VVD"}).ToArray();
+    private static readonly string[] DisallowedFromSidecode8Onwards =
+        {"SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS", "KVT", "VVD"};
 
     private static readonly string[] DisallowedFromSidecode13Onwards =
-        DisallowedFromSidecode8Onwards.Concat(new[] {"SP"}).ToArray();
+        {"SD", "SS", "SA", "WA", "GVD", "KKK", "LPF", "NSB", "PKK", "PSV", "PVV", "SGP", "TBS", "KVT", "VVD", "SP"};
 }

--- a/src/Kenteken.cs
+++ b/src/Kenteken.cs
@@ -43,18 +43,18 @@ public sealed class Kenteken : IEquatable<Kenteken>
         var regex = Formats.Sidecodes[Sidecode - 1];
         var captures = Regex.Match(input.ToString(), regex, RegexOptions.IgnoreCase).Groups;
         var result = new Span<char>(new char[8]);
-        var curLen = 0;
-        
-        captures[1].ValueSpan.ToUpperInvariant(destination: result.Slice(0, captures[1].ValueSpan.Length));
-        curLen = captures[1].ValueSpan.Length;
+
+        // skip first capture because it contains the whole regex
+        captures[1].ValueSpan.ToUpperInvariant(destination: result.Slice(0, captures[1].Length));
+        var currentLength = captures[1].ValueSpan.Length;
         
         for (var i = 2; i < captures.Count; i++)
         {
             var capture = captures[i];
             var valueSpan = capture.ValueSpan;
-            result[curLen] = '-';
-            valueSpan.ToUpperInvariant(destination: result.Slice(curLen + 1, capture.Length));
-            curLen += capture.Length + 1;
+            result[currentLength] = '-';
+            valueSpan.ToUpperInvariant(destination: result.Slice(currentLength + 1, capture.Length));
+            currentLength += capture.Length + 1;
         }
         
         return result.ToString();

--- a/src/Kenteken.cs
+++ b/src/Kenteken.cs
@@ -21,22 +21,40 @@ public sealed class Kenteken : IEquatable<Kenteken>
     /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
     public Kenteken(string input)
     {
-        Sidecode = GetSidecode(input);
+        Sidecode = GetSidecode(input.AsSpan());
         Formatted = Format(input);
+    }
+    
+    /// <summary>
+    /// Creates a new instance of a Kenteken.
+    /// </summary>
+    /// <param name="input">A string containing the Kenteken to parse.</param>
+    /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
+    public Kenteken(ReadOnlySpan<char> input)
+    {
+        Sidecode = GetSidecode(input);
+        
+        // Regex.Match does not exist for ReadOnlySpan<char>
+        Formatted = Format(input.ToString());
     }
 
     private string Format(string input)
     {
-        var sidecode = Formats.Sidecodes
-            .Single(r => r.Sidecode == Sidecode);
+        var sidecode = Formats.Sidecodes[Sidecode - 1];
 
         return Regex.Match(input, sidecode.Regex, RegexOptions.IgnoreCase)
+            // get the capture groups for the desired sidecode
             .Groups
+            // use cast to filter nulls
             .Cast<Group>()
+            // skip first capture because it's the whole thing
             .Skip(1)
+            // use cast to filter nulls
             .Cast<Capture>()
             .Select(c => c.Value)
+            // add dashes between the capture group to create the formatted variant
             .Aggregate(string.Empty, (a, b) => a.Length > 0 ? a + "-" + b : b)
+            // format should always be uppercase
             .ToUpperInvariant();
     }
 
@@ -59,26 +77,66 @@ public sealed class Kenteken : IEquatable<Kenteken>
     }
     
     /// <summary>
+    /// Converts the string representation of the Kenteken to a Kenteken equivalent. A return value indicates whether the conversion succeeded.
+    /// </summary>
+    /// <param name="input">A string containing the Kenteken to parse.</param>
+    /// <param name="kenteken">Contains the Kenteken if parsing was successful, null otherwise.</param>
+    /// <returns>true if <paramref name="input">input</paramref> was converted successfully; otherwise, false.</returns>
+    public static bool TryParse(ReadOnlySpan<char> input, out Kenteken kenteken)
+    {
+        if (Validate(input))
+        {
+            kenteken = new Kenteken(input);
+            return true;
+        }
+        
+        kenteken = null;
+        return false;
+    }
+    
+    /// <summary>
     /// Converts the string representation of the Kenteken to a Kenteken equivalent.
     /// </summary>
     /// <param name="input">A string containing the Kenteken to parse.</param>
     /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
     public static Kenteken Parse(string input) => new(input);
+    
+    /// <summary>
+    /// Converts the string representation of the Kenteken to a Kenteken equivalent.
+    /// </summary>
+    /// <param name="input">A string containing the Kenteken to parse.</param>
+    /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
+    public static Kenteken Parse(ReadOnlySpan<char> input) => new(input);
 
     /// <summary>
     /// Validates whether the input is a valid Kenteken.
     /// </summary>
     /// <param name="input">A string containing the Kenteken to parse.</param>
     /// <returns>true if <paramref name="input">input</paramref> was converted successfully; otherwise, false.</returns>
-    public static bool Validate(string input) => input is not null && Formats.GetSidecode(input) is not null;
+    public static bool Validate(string input) => !string.IsNullOrWhiteSpace(input) && Formats.GetSidecode(input) is not null;
+    
+    /// <summary>
+    /// Validates whether the input is a valid Kenteken.
+    /// </summary>
+    /// <param name="input">A string containing the Kenteken to parse.</param>
+    /// <returns>true if <paramref name="input">input</paramref> was converted successfully; otherwise, false.</returns>
+    public static bool Validate(ReadOnlySpan<char> input) => !input.IsEmpty && !input.IsWhiteSpace() && Formats.GetSidecode(input) is not null;
 
     /// <summary>
     /// Gets the sidecode associated with a Kenteken.
     /// </summary>
     /// <param name="input">A string containing the Kenteken to get the sidecode for.</param>
-    /// <returns></returns>
+    /// <returns>The sidecode</returns>
     /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
     public static int GetSidecode(string input) => Formats.GetSidecode(input) ?? throw new FormatException("Invalid format");
+    
+    /// <summary>
+    /// Gets the sidecode associated with a Kenteken.
+    /// </summary>
+    /// <param name="input">A string containing the Kenteken to get the sidecode for.</param>
+    /// <returns>The sidecode</returns>
+    /// <exception cref="T:System.FormatException">When the Kenteken is invalid.</exception>
+    public static int GetSidecode(ReadOnlySpan<char> input) => Formats.GetSidecode(input) ?? throw new FormatException("Invalid format");
 
     public override string ToString() => Formatted;
 

--- a/src/Kenteken.cs
+++ b/src/Kenteken.cs
@@ -37,6 +37,13 @@ public sealed class Kenteken : IEquatable<Kenteken>
         Sidecode = GetSidecode(input);
         Formatted = Format(input);
     }
+    
+    // internal constructor for when the sidecode is already known
+    private Kenteken(ReadOnlySpan<char> input, int sidecode)
+    {
+        Sidecode = sidecode;
+        Formatted = Format(input);
+    }
 
     private string Format(ReadOnlySpan<char> input)
     {
@@ -83,7 +90,7 @@ public sealed class Kenteken : IEquatable<Kenteken>
         var sidecode = Formats.GetSidecode(input);
         if (sidecode is null) return false;
         
-        kenteken = new Kenteken(input);
+        kenteken = new Kenteken(input, sidecode.Value);
         return true;
     }
     

--- a/src/Tvans.Kenteken.csproj
+++ b/src/Tvans.Kenteken.csproj
@@ -4,7 +4,7 @@
         <IsPackable>true</IsPackable>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
-        <Version>1.0.1</Version>
+        <Version>2.0.0</Version>
         <Authors>T. van Schagen</Authors>
         <PackageDescription>Allows parsing, formatting, and validating dutch license plates.</PackageDescription>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Tvans.Kenteken.csproj
+++ b/src/Tvans.Kenteken.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
         <Version>1.0.1</Version>
@@ -20,6 +19,7 @@
         <AssemblyVersion>1.0.1</AssemblyVersion>
         <FileVersion>1.0.1</FileVersion>
         <PackageVersion>1.0.1</PackageVersion>
+        <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/Tvans.Kenteken.csproj
+++ b/src/Tvans.Kenteken.csproj
@@ -16,9 +16,9 @@
         <PackageIcon>icon.png</PackageIcon>
         <PackageTags>kenteken licenseplate validation parsing</PackageTags>
         <NeutralLanguage>en</NeutralLanguage>
-        <AssemblyVersion>1.0.1</AssemblyVersion>
-        <FileVersion>1.0.1</FileVersion>
-        <PackageVersion>1.0.1</PackageVersion>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
+        <PackageVersion>2.0.0</PackageVersion>
         <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
     

--- a/test/KentekenTests.cs
+++ b/test/KentekenTests.cs
@@ -31,7 +31,7 @@ public class KentekenTests
     [InlineData("9-sp-999")]
     [InlineData("9SP999")]
     [InlineData("9sp999")]
-    public void Is_a_invalid_kenteken_because_it_contains_forbidden_combinations(string kenteken)
+    public void Is_an_invalid_kenteken_because_it_contains_forbidden_combinations(string kenteken)
     {
         var valid = Kenteken.Validate(kenteken);
         

--- a/test/KentekenTests.cs
+++ b/test/KentekenTests.cs
@@ -17,6 +17,26 @@ public class KentekenTests
         
         valid.Should().BeTrue();
     }
+    
+    [Theory]
+    [InlineData("SS-55-55")]
+    [InlineData("ss-55-55")]
+    [InlineData("SS5555")]
+    [InlineData("ss5555")]
+    [InlineData("6-VVD-86")]
+    [InlineData("6-vvd-86")]
+    [InlineData("6VVD86")]
+    [InlineData("6vvd86")]
+    [InlineData("9-SP-999")]
+    [InlineData("9-sp-999")]
+    [InlineData("9SP999")]
+    [InlineData("9sp999")]
+    public void Is_a_invalid_kenteken_because_it_contains_forbidden_combinations(string kenteken)
+    {
+        var valid = Kenteken.Validate(kenteken);
+        
+        valid.Should().BeFalse();
+    }
 
     [Theory]
     [InlineData("GJ-55-55", 1)]


### PR DESCRIPTION
- feat(perf): use generated regex for better performance
- feat(perf): use Span and ReadOnlySpan where possible for better performance
- chore: drop support for .NET standard 2.0 and thus .NET Framework
- chore: bump version to 2.0.0 due to breaking change in dropping support for older frameworks

Improvements:

**Old**
| Method      | Input    | Mean       | Error    | StdDev   | Gen0   | Allocated |
|------------ |--------- |-----------:|---------:|---------:|-------:|----------:|
| GetSidecode | 99-99-XX |   972.6 ns | 11.63 ns | 10.31 ns | 0.0515 |     216 B |
| New         | 99-99-XX | 2,169.2 ns | 26.42 ns | 23.42 ns | 0.2937 |    1232 B |
| GetSidecode | 99-XX-99 | 1,343.3 ns | 23.49 ns | 20.82 ns | 0.0515 |     216 B |
| New         | 99-XX-99 | 2,570.5 ns | 14.35 ns | 11.98 ns | 0.2937 |    1232 B |
| GetSidecode | 99-XX-XX | 2,251.0 ns | 43.48 ns | 40.67 ns | 0.0496 |     216 B |
| New         | 99-XX-XX | 3,482.8 ns | 14.88 ns | 13.19 ns | 0.2937 |    1232 B |


**New**
| Method      | Input    | Mean       | Error    | StdDev    | Gen0   | Allocated |
|------------ |--------- |-----------:|---------:|----------:|-------:|----------:|
| GetSidecode | 99-99-XX |   413.1 ns |  4.90 ns |   4.58 ns |      - |         - |
| New         | 99-99-XX | 1,305.7 ns | 49.49 ns | 145.92 ns | 0.1831 |     768 B |
| GetSidecode | 99-XX-99 |   504.3 ns | 10.04 ns |  13.41 ns |      - |         - |
| New         | 99-XX-99 | 1,237.2 ns | 17.83 ns |  15.81 ns | 0.1831 |     768 B |
| GetSidecode | 99-XX-XX |   722.3 ns | 14.46 ns |  15.48 ns |      - |         - |
| New         | 99-XX-XX | 1,426.6 ns | 27.22 ns |  25.46 ns | 0.1831 |     768 B |
